### PR TITLE
chore: gitpod and devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/python
+{
+  "name": "Python 3.11",
+  // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+  "image": "mcr.microsoft.com/devcontainers/python:0-3.11-bullseye",
+  "features": {
+    "ghcr.io/devcontainers-contrib/features/coverage-py:2": {},
+    "node": {
+      "version": "v23.3.0",
+      "nodeGypDependencies": true
+    }
+  },
+
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [],
+
+  // Configure tool-specific properties.
+  "customizations": {
+    // Configure properties specific to VS Code.
+    "vscode": {
+      // Add the IDs of extensions you want installed when the container is created.
+      "extensions": [
+        "streetsidesoftware.code-spell-checker"
+      ]
+    }
+  }
+
+  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+  // "remoteUser": "root"
+}

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,1 @@
+FROM gitpod/workspace-full:latest

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -19,4 +19,8 @@ RUN source $NVM_DIR/nvm.sh \
 ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 
+# install pnpm
+RUN npm i -g pnpm
+
+# set server url for web client
 ENV VITE_SERVER_URL $(gp url 3000)

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,4 +1,4 @@
-FROM workspace-python-3.11
+FROM gitpod/workspace-python-3.11
 
 # nvm environment variables
 ENV NVM_DIR /usr/local/nvm

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -27,6 +27,3 @@ ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 
 # install pnpm
 RUN npm i -g pnpm
-
-# set server url for web client
-ENV VITE_SERVER_URL $(gp url 3000)

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -25,5 +25,8 @@ ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 # install pnpm
 RUN npm i -g pnpm
 
+# copy .env file
+RUN cp .env.example .env
+
 # set server url for web client
 ENV VITE_SERVER_URL $(gp url 3000)

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,23 +1,21 @@
 FROM gitpod/workspace-python-3.11
 
 # nvm environment variables
-ENV NVM_DIR /usr/local/nvm
 ENV NODE_VERSION 23.3.0
 
 # install nvm
 # https://github.com/creationix/nvm#install-script
-RUN mkdir $NVM_DIR
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
 
+# set environment variables
+ENV NVM_DIR $HOME/.nvm
+RUN echo 'export NVM_DIR="$HOME/.nvm"' >> $HOME/.bashrc
+RUN echo '[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" ' >> $HOME/.bashrc
+
 # install node and npm
-RUN source $NVM_DIR/nvm.sh \
-    && nvm install $NODE_VERSION \
+RUN nvm install $NODE_VERSION \
     && nvm alias default $NODE_VERSION \
     && nvm use default
-
-# add node and npm to path so the commands are available
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 
 # install pnpm
 RUN npm i -g pnpm

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -25,8 +25,5 @@ ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 # install pnpm
 RUN npm i -g pnpm
 
-# copy .env file
-RUN cp .env.example .env
-
 # set server url for web client
 ENV VITE_SERVER_URL $(gp url 3000)

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,1 +1,21 @@
-FROM gitpod/workspace-full:latest
+FROM workspace-python-3.11
+
+# nvm environment variables
+ENV NVM_DIR /usr/local/nvm
+ENV NODE_VERSION 23.3.0
+
+# install nvm
+# https://github.com/creationix/nvm#install-script
+RUN curl --silent -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
+
+# install node and npm
+RUN source $NVM_DIR/nvm.sh \
+    && nvm install $NODE_VERSION \
+    && nvm alias default $NODE_VERSION \
+    && nvm use default
+
+# add node and npm to path so the commands are available
+ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
+ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
+
+ENV VITE_SERVER_URL $(gp url 3000)

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -18,6 +18,10 @@ RUN . $NVM_DIR/nvm.sh \
     && nvm alias default $NODE_VERSION \
     && nvm use default
 
+# add node and npm to path so the commands are available
+ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
+ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
+
 # install pnpm
 RUN npm i -g pnpm
 

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,5 +1,8 @@
 FROM gitpod/workspace-python-3.11
 
+# install NEAR AI CLI
+RUN bash -cl "python -m pip install nearai"
+
 # nvm environment variables
 ENV NODE_VERSION 23.3.0
 

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -13,7 +13,8 @@ RUN echo 'export NVM_DIR="$HOME/.nvm"' >> $HOME/.bashrc
 RUN echo '[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" ' >> $HOME/.bashrc
 
 # install node and npm
-RUN nvm install $NODE_VERSION \
+RUN source $NVM_DIR/nvm.sh \
+    && nvm install $NODE_VERSION \
     && nvm alias default $NODE_VERSION \
     && nvm use default
 

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -13,7 +13,7 @@ RUN echo 'export NVM_DIR="$HOME/.nvm"' >> $HOME/.bashrc
 RUN echo '[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" ' >> $HOME/.bashrc
 
 # install node and npm
-RUN source $NVM_DIR/nvm.sh \
+RUN . $NVM_DIR/nvm.sh \
     && nvm install $NODE_VERSION \
     && nvm alias default $NODE_VERSION \
     && nvm use default

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -6,7 +6,7 @@ ENV NODE_VERSION 23.3.0
 
 # install nvm
 # https://github.com/creationix/nvm#install-script
-RUN curl --silent -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
 
 # install node and npm
 RUN source $NVM_DIR/nvm.sh \

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -6,6 +6,7 @@ ENV NODE_VERSION 23.3.0
 
 # install nvm
 # https://github.com/creationix/nvm#install-script
+RUN mkdir $NVM_DIR
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
 
 # install node and npm

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -19,10 +19,11 @@ tasks:
       [ -f ~/.nearai/config.json ] || (printf "\n\n*** NEAR AI login ***\n\n" && nearai login --remote)
   - name: Create NEAR Testnet Account
     init: |
+      NEAR_CREDENTIALS_TESTNET_DIR=~/.near-credentials/testnet
+      [ -d "'$NEAR_CREDENTIALS_TESTNET_DIR'" ] || exit
       npm i -g near-cli-rs
       cp .env.example .env
       near account create-account sponsor-by-faucet-service eliza-$(date +%s%3N).testnet autogenerate-new-keypair save-to-legacy-keychain network-config testnet create
-      NEAR_CREDENTIALS_TESTNET_DIR=~/.near-credentials/testnet
       NEAR_ACCOUNT_JSON_FILE=$(ls $NEAR_CREDENTIALS_TESTNET_DIR/*.json | head -n 1)
       NEAR_ACCOUNT_KEYS=$(cat $NEAR_ACCOUNT_JSON_FILE)
       NEAR_ADDRESS=$(basename $NEAR_ACCOUNT_JSON_FILE .json)

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -33,4 +33,6 @@ tasks:
   - name: Agent Server
     init: pnpm i
   - name: Web Client
+    before: export VITE_SERVER_URL=$(gp url 3000)
     init: cd client && pnpm i && cd ..
+    command: pnpm start:client

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,7 +4,9 @@ image:
 tasks:
   - name: Set up NEAR AI CLI
     init: python -m pip install nearai
+    command: nearai login --remote
   - name: Install agent dependencies
     init: pnpm i
   - name: Install web client dependencies
+    before: export VITE_SERVER_URL=$(gp url 3000)
     init: cd client && pnpm i && cd ..

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -16,7 +16,7 @@ tasks:
   - name: NEAR AI CLI
     init: python -m pip install nearai
     command: |
-      [ -f ~/.nearai/config.json ] || nearai login --remote
+      [ -f ~/.nearai/config.json ] || (printf "\n\n*** NEAR AI login ***\n\n" && nearai login --remote)
   - name: Create NEAR Testnet Account
     init: |
       npm i -g near-cli-rs

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -21,7 +21,7 @@ tasks:
     init: |
       npm i -g near-cli-rs
       cp .env.example .env
-      near account create-account sponsor-by-faucet-service eliza-$(date +%s).testnet autogenerate-new-keypair save-to-legacy-keychain network-config testnet create
+      near account create-account sponsor-by-faucet-service eliza-$(date +%s%3N).testnet autogenerate-new-keypair save-to-legacy-keychain network-config testnet create
       NEAR_CREDENTIALS_TESTNET_DIR=~/.near-credentials/testnet
       NEAR_ACCOUNT_JSON_FILE=$(ls $NEAR_CREDENTIALS_TESTNET_DIR/*.json | head -n 1)
       NEAR_ACCOUNT_KEYS=$(cat $NEAR_ACCOUNT_JSON_FILE)

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,16 +2,16 @@ image:
   file: .gitpod.Dockerfile
 # List the start up tasks. You can start them in parallel in multiple terminals. See https://www.gitpod.io/docs/config-start-tasks/
 ports:
-    - name: Agent Server
-      description: The agent API server
-      port: 3000
-      onOpen: ignore
-      visibility: public
-    - name: Web Client
-      description: The web client to chat with the agent
-      port: 5173
-      onOpen: open-browser
-      visibility: public
+  - name: Agent Server
+    description: The agent API server
+    port: 3000
+    onOpen: ignore
+    visibility: public
+  - name: Web Client
+    description: The web client to chat with the agent
+    port: 5173
+    onOpen: open-browser
+    visibility: public
 tasks:
   - name: Set up NEAR AI CLI
     init: python -m pip install nearai

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -21,14 +21,13 @@ tasks:
   - name: Create NEAR Testnet Account
     init: |
       npm i -g near-cli-rs
-      cp .env.example .env
       near create-dev-account use-random-account-id autogenerate-new-keypair save-to-legacy-keychain network-config testnet create
       NEAR_CREDENTIALS_TESTNET_DIR=~/.near-credentials/testnet
       NEAR_ACCOUNT_KEYS=$(cat $NEAR_CREDENTIALS_TESTNET_DIR/$(ls $NEAR_CREDENTIALS_TESTNET_DIR | head -n 1))
       NEAR_ADDRESS=$(echo $NEAR_ACCOUNT_KEYS | jq -r ".account_id")
       NEAR_WALLET_SECRET_KEY=$(echo $NEAR_ACCOUNT_KEYS | jq -r ".private_key")
       sed -i 's/NEAR_ADDRESS=.*$/NEAR_ADDRESS='${NEAR_ADDRESS}'/g' .env
-      sed -i "" 's/NEAR_WALLET_SECRET_KEY=.*$/NEAR_WALLET_SECRET_KEY='${NEAR_WALLET_SECRET_KEY}'/g' .env.test
+      sed -i 's/NEAR_WALLET_SECRET_KEY=.*$/NEAR_WALLET_SECRET_KEY='${NEAR_WALLET_SECRET_KEY}'/g' .env
   - name: Agent Server
     init: pnpm i
   - name: Web Client

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -21,6 +21,7 @@ tasks:
   - name: Create NEAR Testnet Account
     init: |
       npm i -g near-cli-rs
+      cp .env.example .env
       near create-dev-account use-random-account-id autogenerate-new-keypair save-to-legacy-keychain network-config testnet create
       NEAR_CREDENTIALS_TESTNET_DIR=~/.near-credentials/testnet
       NEAR_ACCOUNT_KEYS=$(cat $NEAR_CREDENTIALS_TESTNET_DIR/$(ls $NEAR_CREDENTIALS_TESTNET_DIR | head -n 1))

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -16,9 +16,17 @@ tasks:
   - name: Set up NEAR AI CLI
     init: python -m pip install nearai
     command: nearai login --remote
-  - name: Install agent dependencies
-    init: |
-      pnpm i
+  - name: Create NEAR dev account on testnet
+    init: npm i -g near-cli-rs
+    command: |
       cp .env.example .env
+      near create-dev-account use-random-account-id autogenerate-new-keypair save-to-legacy-keychain network-config testnet create
+      NEAR_ACCOUNT_KEYS=$(cat ~/.near-credentials/testnet/$(ls ~/.near-credentials/testnet | head -n 1))
+      NEAR_ADDRESS=$(echo $NEAR_ACCOUNT_KEYS | jq -r ".account_id")
+      NEAR_WALLET_SECRET_KEY=$(echo $NEAR_ACCOUNT_KEYS | jq -r ".private_key")
+      sed -i 's/NEAR_ADDRESS=.*$/NEAR_ADDRESS='${NEAR_ADDRESS}'/g' .env
+      sed -i "" 's/NEAR_WALLET_SECRET_KEY=.*$/NEAR_WALLET_SECRET_KEY='${NEAR_WALLET_SECRET_KEY}'/g' .env.test
+  - name: Install agent dependencies
+    init: pnpm i
   - name: Install web client dependencies
     init: cd client && pnpm i && cd ..

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -14,7 +14,6 @@ ports:
     visibility: public
 tasks:
   - name: NEAR AI CLI
-    init: python -m pip install nearai
     command: |
       nearai login --remote
       echo "Open the above link to login NEAR AI if you haven't done so. Skip this step if it's already completed."
@@ -22,10 +21,11 @@ tasks:
     init: |
       npm i -g near-cli-rs
       cp .env.example .env
-      near create-dev-account use-random-account-id autogenerate-new-keypair save-to-legacy-keychain network-config testnet create
+      near account create-account sponsor-by-faucet-service eliza-$(date +%s).testnet autogenerate-new-keypair save-to-legacy-keychain network-config testnet create
       NEAR_CREDENTIALS_TESTNET_DIR=~/.near-credentials/testnet
-      NEAR_ACCOUNT_KEYS=$(cat $NEAR_CREDENTIALS_TESTNET_DIR/$(ls $NEAR_CREDENTIALS_TESTNET_DIR | head -n 1))
-      NEAR_ADDRESS=$(echo $NEAR_ACCOUNT_KEYS | jq -r ".account_id")
+      NEAR_ACCOUNT_JSON_FILE=$(ls $NEAR_CREDENTIALS_TESTNET_DIR/*.json | head -n 1)
+      NEAR_ACCOUNT_KEYS=$(cat $NEAR_ACCOUNT_JSON_FILE)
+      NEAR_ADDRESS=$(basename $NEAR_ACCOUNT_JSON_FILE .json)
       NEAR_WALLET_SECRET_KEY=$(echo $NEAR_ACCOUNT_KEYS | jq -r ".private_key")
       sed -i 's/NEAR_ADDRESS=.*$/NEAR_ADDRESS='${NEAR_ADDRESS}'/g' .env
       sed -i 's/NEAR_WALLET_SECRET_KEY=.*$/NEAR_WALLET_SECRET_KEY='${NEAR_WALLET_SECRET_KEY}'/g' .env

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -21,7 +21,8 @@ tasks:
     command: |
       cp .env.example .env
       near create-dev-account use-random-account-id autogenerate-new-keypair save-to-legacy-keychain network-config testnet create
-      NEAR_ACCOUNT_KEYS=$(cat ~/.near-credentials/testnet/$(ls ~/.near-credentials/testnet | head -n 1))
+      NEAR_CREDENTIALS_TESTNET_DIR=~/.near-credentials/testnet
+      NEAR_ACCOUNT_KEYS=$(cat $NEAR_CREDENTIALS_TESTNET_DIR/$(ls $NEAR_CREDENTIALS_TESTNET_DIR | head -n 1))
       NEAR_ADDRESS=$(echo $NEAR_ACCOUNT_KEYS | jq -r ".account_id")
       NEAR_WALLET_SECRET_KEY=$(echo $NEAR_ACCOUNT_KEYS | jq -r ".private_key")
       sed -i 's/NEAR_ADDRESS=.*$/NEAR_ADDRESS='${NEAR_ADDRESS}'/g' .env

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -14,9 +14,9 @@ ports:
     visibility: public
 tasks:
   - name: NEAR AI CLI
+    init: python -m pip install nearai
     command: |
-      nearai login --remote
-      echo "Open the above link to login NEAR AI if you haven't done so. Skip this step if it's already completed."
+      [ -f ~/.nearai/config.json ] || nearai login --remote
   - name: Create NEAR Testnet Account
     init: |
       npm i -g near-cli-rs

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -13,10 +13,10 @@ ports:
     onOpen: open-browser
     visibility: public
 tasks:
-  - name: Set up NEAR AI CLI
+  - name: NEAR AI CLI
     init: python -m pip install nearai
     command: nearai login --remote
-  - name: Create NEAR dev account on testnet
+  - name: Create NEAR Testnet Account
     init: npm i -g near-cli-rs
     command: |
       cp .env.example .env
@@ -27,7 +27,7 @@ tasks:
       NEAR_WALLET_SECRET_KEY=$(echo $NEAR_ACCOUNT_KEYS | jq -r ".private_key")
       sed -i 's/NEAR_ADDRESS=.*$/NEAR_ADDRESS='${NEAR_ADDRESS}'/g' .env
       sed -i "" 's/NEAR_WALLET_SECRET_KEY=.*$/NEAR_WALLET_SECRET_KEY='${NEAR_WALLET_SECRET_KEY}'/g' .env.test
-  - name: Install agent dependencies
+  - name: Agent Server
     init: pnpm i
-  - name: Install web client dependencies
+  - name: Web Client
     init: cd client && pnpm i && cd ..

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,10 @@
+image:
+  file: .gitpod.Dockerfile
+# List the start up tasks. You can start them in parallel in multiple terminals. See https://www.gitpod.io/docs/config-start-tasks/
+tasks:
+  - name: Set up NEAR AI CLI
+    init: python -m pip install nearai
+  - name: Install agent dependencies
+    init: pnpm i
+  - name: Install web client dependencies
+    init: cd client && pnpm i && cd ..

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -15,10 +15,12 @@ ports:
 tasks:
   - name: NEAR AI CLI
     init: python -m pip install nearai
-    command: nearai login --remote
-  - name: Create NEAR Testnet Account
-    init: npm i -g near-cli-rs
     command: |
+      nearai login --remote
+      echo "Open the above link to login NEAR AI if you haven't done so. Skip this step if it's already completed."
+  - name: Create NEAR Testnet Account
+    init: |
+      npm i -g near-cli-rs
       cp .env.example .env
       near create-dev-account use-random-account-id autogenerate-new-keypair save-to-legacy-keychain network-config testnet create
       NEAR_CREDENTIALS_TESTNET_DIR=~/.near-credentials/testnet

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,12 +1,24 @@
 image:
   file: .gitpod.Dockerfile
 # List the start up tasks. You can start them in parallel in multiple terminals. See https://www.gitpod.io/docs/config-start-tasks/
+ports:
+    - name: Agent Server
+      description: The agent API server
+      port: 3000
+      onOpen: ignore
+      visibility: public
+    - name: Web Client
+      description: The web client to chat with the agent
+      port: 5173
+      onOpen: open-browser
+      visibility: public
 tasks:
   - name: Set up NEAR AI CLI
     init: python -m pip install nearai
     command: nearai login --remote
   - name: Install agent dependencies
-    init: pnpm i
+    init: |
+      pnpm i
+      cp .env.example .env
   - name: Install web client dependencies
-    before: export VITE_SERVER_URL=$(gp url 3000)
     init: cd client && pnpm i && cd ..

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # near-eliza-starter
 
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/think-in-universe/near-eliza-starter)
+
 <img src="https://github.com/user-attachments/assets/b0ed9973-aa87-4602-93c3-e9d723279045" alt="Description" width="100">
 <img src="https://github.com/user-attachments/assets/d47b5bdd-3e9b-4e2c-ac7a-7edc66978baf" alt="Description" width="100">
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # near-eliza-starter
 
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/think-in-universe/near-eliza-starter)
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/near-agent/near-eliza-starter)
 
 <img src="https://github.com/user-attachments/assets/b0ed9973-aa87-4602-93c3-e9d723279045" alt="Description" width="100">
 <img src="https://github.com/user-attachments/assets/d47b5bdd-3e9b-4e2c-ac7a-7edc66978baf" alt="Description" width="100">

--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
     "@elizaos/plugin-near": "npm:@near-agent/elizaos-plugin-near@0.1.9-patch.2",
     "@elizaos/plugin-node": "0.1.9",
     "@tavily/core": "0.0.2",
-    "multichain-tools": "4.0.0",
     "amqplib": "0.10.5",
     "better-sqlite3": "11.5.0",
     "fs": "0.0.1-security",
+    "multichain-tools": "4.0.0",
     "net": "1.0.2",
     "path": "0.12.7",
     "readline": "1.3.0",
@@ -45,12 +45,15 @@
     "overrides": {
       "@elizaos/core@0.1.9": "npm:@near-agent/elizaos-core@0.1.9-patch.2",
       "onnxruntime-node": "1.20.0"
-    }
+    },
+    "onlyBuiltDependencies": [
+      "better-sqlite3"
+    ]
   },
   "devDependencies": {
+    "pm2": "5.4.3",
     "ts-node": "10.9.2",
     "tsup": "8.3.5",
-    "typescript": "5.6.3",
-    "pm2": "5.4.3" 
+    "typescript": "5.6.3"
   }
 }


### PR DESCRIPTION
### Added gitpod:

Environment
1. python 3.11
2. node v23.3.0

After open the workspace in gitpod, it will automatically:

1. install `nearai` with python 3.11 and run `nearai login --remote`
2. `pnpm install` for agent and web client
3. automatically create NEAR testnet account and add the account ID and private key to `.env`
4. start the web client with `pnpm start:client` automatically, waiting for agent to start

The developer needs to:

1. click the link in NEAR AI terminal tab to login NEAR AI
2. start agent with `pnpm start` in Agent Server terminal tab

### Added devcontainer

Environment
1. python 3.11
2. node v23.3.0


